### PR TITLE
XSet collection - contains methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,31 @@
 
 ## Overview
 
-Extended set - `XSet` is a set that can be either a standard finite set or a complement of a standard finite set.
-The standard set operations are supported: complement, subtraction, instersection and union.
+This is a Java library that allows working with sets and complementary sets.
+
+TODO - WORK IN PROGRESS
+
+
+## Core Classes
+
+### XSet
+
+This class is an extension of a finite set.
+It can hold both finite sets and those inifite ones that can be represented as a complement of finite sets.
+
+The standard set operations are supported: contains, containsAll, containsAny, complement, subtraction, instersection and union.
 `XSet` is a generic type.
+
+The implementation maintains a finite `Set` of `items` and a `boolean` flag `complementary`.
+The `items` should hold only a given type of elements - according to the generic type (e.g. "String" or "Long").
+The `items` cannot hold `null` elements.
+
+The `XSet` cannot directly implement `java.util.Collection`, because the method `java.util.Collection#contains(Object}`
+is not type-safe and we cannot implement such method here.
+Instead of that we implement method with the same name, but taking as the parameter only objects of the given type.
+
+This class is immutable - once created its content cannot be changed.
+It also means that this class is thread-safe.
 
 Examples:
 
@@ -17,11 +39,22 @@ Examples:
 XSet<String> weekend = XSet.of("Sat", "Sun");
 XSet<String> weekdays = weekend.complement();
 
+assert weekend.contains("Sat");
+assert !weekend.contains("Mon");
+
+assert weekdays.contains("Mon");
+assert !weekdays.contains("Sat");
+
+assert !weekdays.containsAll("Mon", "Sun");
+assert weekdays.containsAny("Mon", "Sun");
+
 assert weekdays.equals(XSet.complementOf("Sat", "Sun"));
 assert weekdays.complement().equals(weekend);
+
 assert weekdays.union(weekend).equals(XSet.full());
+
 assert weekdays.intersect(weekend).equals(XSet.empty());
+
 assert weekend.subtract(XSet.of("Sat", "Mon")).equals(XSet.of("Sun"));
 ```
 
-TODO - WORK IN PROGRESS

--- a/code-style/checkstyle/checkstyle-config.xml
+++ b/code-style/checkstyle/checkstyle-config.xml
@@ -115,6 +115,14 @@
       <property name="processJavadoc" value="false"/>
     </module>
 
+    <module name="ImportOrder">
+      <property name="option" value="top"/>
+      <property name="groups" value="/^java\./,javax,org"/>
+      <property name="ordered" value="true"/>
+      <property name="separated" value="true"/>
+      <property name="sortStaticImportsAlphabetically" value="true"/>
+    </module>
+
     <!-- Checks for Size Violations.                    -->
     <!-- See https://checkstyle.org/config_sizes.html -->
     <module name="MethodLength"/>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,18 @@
         <pluginManagement>
             <plugins>
 
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                    <configuration>
+                        <compilerArgs>
+                            <arg>-Xlint:unchecked</arg>
+                            <arg>-Xlint:deprecation</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+
                 <!-- Tests -->
 
                 <plugin>
@@ -235,6 +247,31 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>compile-one-file</id>
+            <activation>
+                <property>
+                    <name>test</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/${test}.java</include>
+                            </includes>
+                            <testIncludes>
+                                <testInclude>**/${test}.java</testInclude>
+                            </testIncludes>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/src/main/java/com/spoledge/xset/XSet.java
+++ b/src/main/java/com/spoledge/xset/XSet.java
@@ -19,7 +19,10 @@ import java.util.Set;
  * This class is an extension of a finite set.
  * It can hold both finite sets and those inifite ones that can be represented as a complement of finite sets.
  * <p>
- * The implementation maintains a finite {@link Set} of {@code items} and a {@code boolean} {@code complementary} flag.
+ * The standard set operations are supported: contains, containsAll, containsAny, complement, subtraction, instersection and union.
+ * {@code XSet} is a generic type.
+ * <p>
+ * The implementation maintains a finite {@link Set} of {@code items} and a {@code boolean} flag {@code complementary}.
  * The {@code items} should hold only a given type of elements.
  * The {@code items} cannot hold {@code null} elements.
  * <p>

--- a/src/main/java/com/spoledge/xset/XSet.java
+++ b/src/main/java/com/spoledge/xset/XSet.java
@@ -260,6 +260,7 @@ public final class XSet<E> {
      * @return true if this extended set contains all the elements
      * @throws NullPointerException if the specified collection or any element of the collection is {@code null}
      * @see #contains(Object)
+     * @see #containsAny(Collection)
      */
     public boolean containsAll(final Collection<E> otherItems) {
         requireNonNull(otherItems);
@@ -274,6 +275,36 @@ public final class XSet<E> {
         }
         else {
             return items.containsAll(otherItems);
+        }
+    }
+
+    /**
+     * Returns {@code true} if this extended set contains at least one element of the specified collection or the collection is empty.
+     * <p>
+     * More formally, returns {@code false} if and only if: for each element {@code e} of the {@code otherItems}
+     * the expression {@code this.contains(e)} returns {@code false}.
+     * <p>
+     * That also means that this method returns {@code true} for empty {@code otherItems} collections.
+     *
+     * @param otherItems collection of elements whose presence in this collection is to be tested
+     * @return true if this extended set contains all the elements or the specified collection is empty
+     * @throws NullPointerException if the specified collection or any element of the collection is {@code null}
+     * @see #contains(Object)
+     * @see #containsAll(Collection)
+     */
+    public boolean containsAny(final Collection<E> otherItems) {
+        requireNonNull(otherItems);
+        requireNonNullItems(otherItems);
+
+        if (otherItems.isEmpty()) {
+            return true;
+        }
+        else if (complementary) {
+            return !items.containsAll(otherItems);
+        }
+        else {
+            return otherItems.stream()
+                .anyMatch(items::contains);
         }
     }
 

--- a/src/main/java/com/spoledge/xset/XSet.java
+++ b/src/main/java/com/spoledge/xset/XSet.java
@@ -161,7 +161,7 @@ public final class XSet<E> {
     private static <T> void requireNonNullItems(final Collection<T> collection) {
         // we cannot call contains(null) because the underlying collection might not support nulls
         final boolean containsNullItem = collection.stream()
-            .anyMatch(it -> it == null);
+            .anyMatch(Objects::isNull);
 
         if (containsNullItem) {
             throw new NullPointerException("items must not be null");
@@ -273,8 +273,8 @@ public final class XSet<E> {
             return true;
         }
         else if (complementary) {
-            return !otherItems.stream()
-                .anyMatch(items::contains);
+            return otherItems.stream()
+                .noneMatch(items::contains);
         }
         else {
             return items.containsAll(otherItems);

--- a/src/main/java/com/spoledge/xset/XSet.java
+++ b/src/main/java/com/spoledge/xset/XSet.java
@@ -231,7 +231,7 @@ public final class XSet<E> {
     /**
      * Returns {@code true} if this extended set contains the specified element.
      * <p>
-     * More formally, returns true if and only if this set:
+     * More formally, returns {@code true} if and only if this set:
      * <ul>
      * <li>is a finite set and it contains at least one element {@code e} such that {@code Objects.equals(item, e)}</li>
      * <li>is a complementary set to a finite set {@code F} and {@code !F.contains(item)}</li>
@@ -246,6 +246,35 @@ public final class XSet<E> {
 
         final boolean containsItem = items.contains(item);
         return complementary ? !containsItem : containsItem;
+    }
+
+    /**
+     * Returns {@code true} if this extended set contains all elements of the specified collection.
+     * <p>
+     * More formally, returns {@code true} if and only if: for each element {@code e} of the {@code otherItems}
+     * the expression {@code this.contains(e)} returns {@code true}.
+     * <p>
+     * That also means that this method returns {@code true} for empty {@code otherItems} collections.
+     *
+     * @param otherItems collection of elements whose presence in this collection is to be tested
+     * @return true if this extended set contains all the elements
+     * @throws NullPointerException if the specified collection or any element of the collection is {@code null}
+     * @see #contains(Object)
+     */
+    public boolean containsAll(final Collection<E> otherItems) {
+        requireNonNull(otherItems);
+        requireNonNullItems(otherItems);
+
+        if (otherItems.isEmpty()) {
+            return true;
+        }
+        else if (complementary) {
+            return !otherItems.stream()
+                .anyMatch(items::contains);
+        }
+        else {
+            return items.containsAll(otherItems);
+        }
     }
 
     /**

--- a/src/test/java/com/spoledge/xset/XSetTest.java
+++ b/src/test/java/com/spoledge/xset/XSetTest.java
@@ -199,7 +199,8 @@ class XSetTest {
 
     @Test
     void testContainsNull() {
-        assertThrows(NullPointerException.class, () -> of("Mon").contains(null));
+        final XSet<String> tested = of("Mon");
+        assertThrows(NullPointerException.class, () -> tested.contains(null));
     }
 
     @ParameterizedTest
@@ -232,12 +233,13 @@ class XSetTest {
 
     @Test
     void testContainsAllNull() {
+        final XSet<String> tested = of("Mon");
         final Collection<String> nullCollection = null;
         final Collection<String> nullItemCollection = Collections.singleton((String) null);
 
         assertAll(
-            () -> assertThrows(NullPointerException.class, () -> of("Mon").containsAll(nullCollection), "null collection"),
-            () -> assertThrows(NullPointerException.class, () -> of("Mon").containsAll(nullItemCollection), "null item  collection")
+            () -> assertThrows(NullPointerException.class, () -> tested.containsAll(nullCollection), "null collection"),
+            () -> assertThrows(NullPointerException.class, () -> tested.containsAll(nullItemCollection), "null item  collection")
         );
     }
 
@@ -286,12 +288,13 @@ class XSetTest {
 
     @Test
     void testContainsAnyNull() {
+        final XSet<String> tested = of("Mon");
         final Collection<String> nullCollection = null;
         final Collection<String> nullItemCollection = Collections.singleton((String) null);
 
         assertAll(
-            () -> assertThrows(NullPointerException.class, () -> of("Mon").containsAny(nullCollection), "null collection"),
-            () -> assertThrows(NullPointerException.class, () -> of("Mon").containsAny(nullItemCollection), "null item  collection")
+            () -> assertThrows(NullPointerException.class, () -> tested.containsAny(nullCollection), "null collection"),
+            () -> assertThrows(NullPointerException.class, () -> tested.containsAny(nullItemCollection), "null item  collection")
         );
     }
 

--- a/src/test/java/com/spoledge/xset/XSetTest.java
+++ b/src/test/java/com/spoledge/xset/XSetTest.java
@@ -230,6 +230,60 @@ class XSetTest {
         );
     }
 
+    @Test
+    void testContainsAllNull() {
+        final Collection<String> nullCollection = null;
+        final Collection<String> nullItemCollection = Collections.singleton((String) null);
+
+        assertAll(
+            () -> assertThrows(NullPointerException.class, () -> of("Mon").containsAll(nullCollection), "null collection"),
+            () -> assertThrows(NullPointerException.class, () -> of("Mon").containsAll(nullItemCollection), "null item  collection")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("containsAllParameters")
+    void testContainsAll(final XSet<String> set, final Collection<String> items, final boolean expected) {
+        assertThat("containsAll " + set + " :: " + items, set.containsAll(items), is(expected));
+    }
+
+    static Stream<Arguments> containsAllParameters() {
+        return Stream.of(
+            Arguments.of(empty(), Collections.emptySet(), true),
+            Arguments.of(empty(), Collections.singleton("Mon"), false),
+            Arguments.of(empty(), Arrays.asList("Mon", "Tue"), false),
+
+            Arguments.of(of("Mon"), Collections.emptySet(), true),
+            Arguments.of(of("Mon"), Collections.singleton("Mon"), true),
+            Arguments.of(of("Mon"), Collections.singleton("Tue"), false),
+            Arguments.of(of("Mon"), Arrays.asList("Mon", "Tue"), false),
+            Arguments.of(of("Mon"), Arrays.asList("Mon", "Sun"), false),
+
+            Arguments.of(of("Mon", "Tue"), Collections.singleton("Mon"), true),
+            Arguments.of(of("Mon", "Tue"), Collections.singleton("Tue"), true),
+            Arguments.of(of("Mon", "Tue"), Collections.singleton("Sun"), false),
+            Arguments.of(of("Mon", "Tue"), Arrays.asList("Mon", "Tue"), true),
+            Arguments.of(of("Mon", "Tue"), Arrays.asList("Mon", "Sun"), false),
+
+            Arguments.of(complementOf("Mon", "Tue"), Collections.singleton("Mon"), false),
+            Arguments.of(complementOf("Mon", "Tue"), Collections.singleton("Tue"), false),
+            Arguments.of(complementOf("Mon", "Tue"), Collections.singleton("Sun"), true),
+            Arguments.of(complementOf("Mon", "Tue"), Arrays.asList("Mon", "Tue"), false),
+            Arguments.of(complementOf("Mon", "Tue"), Arrays.asList("Mon", "Sun"), false),
+            Arguments.of(complementOf("Mon", "Tue"), Arrays.asList("Sat", "Sun"), true),
+
+            Arguments.of(complementOf("Mon"), Collections.emptySet(), true),
+            Arguments.of(complementOf("Mon"), Collections.singleton("Mon"), false),
+            Arguments.of(complementOf("Mon"), Collections.singleton("Tue"), true),
+            Arguments.of(complementOf("Mon"), Arrays.asList("Mon", "Tue"), false),
+            Arguments.of(complementOf("Mon"), Arrays.asList("Sat", "Sun"), true),
+
+            Arguments.of(full(), Collections.emptySet(), true),
+            Arguments.of(full(), Collections.singleton("Mon"), true),
+            Arguments.of(full(), Arrays.asList("Mon", "Tue"), true)
+        );
+    }
+
     @ParameterizedTest
     @MethodSource("subtractParameters")
     void testSubtract(final XSet<String> set1, final XSet<String> set2, final XSet<String> expected) {

--- a/src/test/java/com/spoledge/xset/XSetTest.java
+++ b/src/test/java/com/spoledge/xset/XSetTest.java
@@ -284,6 +284,60 @@ class XSetTest {
         );
     }
 
+    @Test
+    void testContainsAnyNull() {
+        final Collection<String> nullCollection = null;
+        final Collection<String> nullItemCollection = Collections.singleton((String) null);
+
+        assertAll(
+            () -> assertThrows(NullPointerException.class, () -> of("Mon").containsAny(nullCollection), "null collection"),
+            () -> assertThrows(NullPointerException.class, () -> of("Mon").containsAny(nullItemCollection), "null item  collection")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("containsAnyParameters")
+    void testContainsAny(final XSet<String> set, final Collection<String> items, final boolean expected) {
+        assertThat("containsAny " + set + " :: " + items, set.containsAny(items), is(expected));
+    }
+
+    static Stream<Arguments> containsAnyParameters() {
+        return Stream.of(
+            Arguments.of(empty(), Collections.emptySet(), true),
+            Arguments.of(empty(), Collections.singleton("Mon"), false),
+            Arguments.of(empty(), Arrays.asList("Mon", "Tue"), false),
+
+            Arguments.of(of("Mon"), Collections.emptySet(), true),
+            Arguments.of(of("Mon"), Collections.singleton("Mon"), true),
+            Arguments.of(of("Mon"), Collections.singleton("Tue"), false),
+            Arguments.of(of("Mon"), Arrays.asList("Mon", "Tue"), true),
+            Arguments.of(of("Mon"), Arrays.asList("Sun", "Sat"), false),
+
+            Arguments.of(of("Mon", "Tue"), Collections.singleton("Mon"), true),
+            Arguments.of(of("Mon", "Tue"), Collections.singleton("Tue"), true),
+            Arguments.of(of("Mon", "Tue"), Collections.singleton("Sun"), false),
+            Arguments.of(of("Mon", "Tue"), Arrays.asList("Mon", "Tue"), true),
+            Arguments.of(of("Mon", "Tue"), Arrays.asList("Mon", "Sun"), true),
+            Arguments.of(of("Mon", "Tue"), Arrays.asList("Sat", "Sun"), false),
+
+            Arguments.of(complementOf("Mon", "Tue"), Collections.singleton("Mon"), false),
+            Arguments.of(complementOf("Mon", "Tue"), Collections.singleton("Tue"), false),
+            Arguments.of(complementOf("Mon", "Tue"), Collections.singleton("Sun"), true),
+            Arguments.of(complementOf("Mon", "Tue"), Arrays.asList("Mon", "Tue"), false),
+            Arguments.of(complementOf("Mon", "Tue"), Arrays.asList("Mon", "Sun"), true),
+            Arguments.of(complementOf("Mon", "Tue"), Arrays.asList("Sat", "Sun"), true),
+
+            Arguments.of(complementOf("Mon"), Collections.singleton("Mon"), false),
+            Arguments.of(complementOf("Mon"), Collections.singleton("Tue"), true),
+            Arguments.of(complementOf("Mon"), Arrays.asList("Mon", "Tue"), true),
+            Arguments.of(complementOf("Mon"), Arrays.asList("Sat", "Sun"), true),
+
+            Arguments.of(full(), Collections.emptySet(), true),
+            Arguments.of(full(), Collections.singleton("Mon"), true),
+            Arguments.of(full(), Arrays.asList("Mon", "Tue"), true)
+        );
+    }
+
     @ParameterizedTest
     @MethodSource("subtractParameters")
     void testSubtract(final XSet<String> set1, final XSet<String> set2, final XSet<String> expected) {


### PR DESCRIPTION
# Overview

Added `contains`, `containsAll` and `containsAny` methods to `XSet`.
Clarified relation to `java.util.Collection`.